### PR TITLE
Use color when diffing and reduce output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ $(BUILD_ROOT)/partitions.csv: initialize-submodules
 
 .PHONY: diff
 diff:
-	@diff -aur $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/sdkconfig.defaults $(BUILD_ROOT)/sdkconfig.defaults || true
-	@diff -aur $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/partitions.csv $(BUILD_ROOT)/partitions.csv || true
+	@diff --color -aur $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/sdkconfig.defaults $(BUILD_ROOT)/sdkconfig.defaults || true
+	@diff --color -aur $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/partitions.csv $(BUILD_ROOT)/partitions.csv || true

--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ $(BUILD_ROOT)/partitions.csv: initialize-submodules
 
 .PHONY: diff
 diff:
-	@diff --color -aur $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/sdkconfig.defaults $(BUILD_ROOT)/sdkconfig.defaults || true
-	@diff --color -aur $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/partitions.csv $(BUILD_ROOT)/partitions.csv || true
+	@diff --color $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/sdkconfig.defaults $(BUILD_ROOT)/sdkconfig.defaults || true
+	@diff --color $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/partitions.csv $(BUILD_ROOT)/partitions.csv || true

--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ $(BUILD_ROOT)/partitions.csv: initialize-submodules
 
 .PHONY: diff
 diff:
-	@diff --color $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/sdkconfig.defaults $(BUILD_ROOT)/sdkconfig.defaults || true
-	@diff --color $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/partitions.csv $(BUILD_ROOT)/partitions.csv || true
+	@diff -U0 --color $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/sdkconfig.defaults $(BUILD_ROOT)/sdkconfig.defaults || true
+	@diff -U0 --color $(TOIT_ROOT)/toolchains/$(IDF_TARGET)/partitions.csv $(BUILD_ROOT)/partitions.csv || true


### PR DESCRIPTION
No need to show adjacent lines when showing configurations.